### PR TITLE
Adding JSON parameter to get_list method.

### DIFF
--- a/third_party/stash/mod.stash.php
+++ b/third_party/stash/mod.stash.php
@@ -1033,7 +1033,8 @@ class Stash {
 		$offset 		= $this->EE->TMPL->fetch_param('offset', FALSE);
 		$default 		= $this->EE->TMPL->fetch_param('default', ''); // default value
 		$filter			= $this->EE->TMPL->fetch_param('filter', NULL); // regex pattern to search final output for
-		
+		$json 			= (bool) preg_match('/1|on|yes|y/i', $this->EE->TMPL->fetch_param('json'));
+
 		$list_html 		= '';
 		$list_markers	= array();
 
@@ -1066,10 +1067,23 @@ class Stash {
 			$list = array_reverse($list);
 		}
 		
+		//get the list in json encoded form
+		if($json)
+		{
+			$list_json = json_encode($list);
+		}	
+
 		// add absolute count to the ordered/sorted items
 		$i=0;
 		foreach($list as $key => &$value)
 		{
+			
+			if($json)
+			{
+				$value['row_json'] = json_encode($value);
+				$value['list_json'] = $list_json;
+			} 
+
 			$i++;
 			$value['absolute_count'] = $i;
 		}


### PR DESCRIPTION
I added a json parameter to the get_list method, which creates two new tags {list_json} and {row_json} available between the get_list tag pair.  

Each tag spits out a json representation of the list (or row) which can be used between script tags to quickly make data available to page scripts.

Example:

```
{exp:stash:get_list name="gallery_images" scope="site" context="site" json="yes"}

{if count == "1"}
<script>
var image_data = '{list_json}';
</script>
{/if}

{/exp:stash:get_list}
```
