### PR TITLE
Feature/magic call

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * Author: [Mark Croxton](http://hallmark-design.co.uk/)
 
-## Version 2.2.5 beta
+## Version 2.2.6 beta
 
 This is the development version of Stash, and introduces Stash embeds and post/pre parsing of variables. Use with caution!
 

--- a/config.php
+++ b/config.php
@@ -2,7 +2,7 @@
 if (! defined('STASH_VER'))
 {
 	define('STASH_NAME', 'Stash');
-	define('STASH_VER',  '2.2.5');
+	define('STASH_VER',  '2.2.6');
 	define('STASH_AUTHOR',  'Mark Croxton');
 	define('STASH_DOCS',  'http://github.com/croxton/Stash/');
 	define('STASH_DESC',  'Stash: save text and code snippets for reuse throughout your templates.');

--- a/ext.stash.php
+++ b/ext.stash.php
@@ -255,8 +255,6 @@ class Stash_ext {
 			// run any postponed stash tags
 			if ( ! empty($cache))
 			{	
-				$this->EE->TMPL->log_item("Stash: post-processing tags");
-				
 				if ( ! class_exists('Stash'))
 				{
 					include_once PATH_THIRD . 'stash/mod.stash.php';
@@ -278,6 +276,8 @@ class Stash_ext {
 					// it may have been removed by advanced conditional processing
 					if ( strpos( $template, $placeholder ) !== FALSE)
 					{
+						$this->EE->TMPL->log_item("Stash: post-processing tag: ".$tag['tagproper']);
+						
 						$this->EE->TMPL->tagparams = $tag['tagparams'];
 						$this->EE->TMPL->tagdata = $tag['tagdata'];
 					

--- a/mod.stash.php
+++ b/mod.stash.php
@@ -126,6 +126,8 @@ class Stash {
 		$this->_session_id =& $this->EE->session->cache['stash']['_session_id'];
 	}
 	
+	// ---------------------------------------------------------
+	
 	/**
 	 * Initialise tag parameters
 	 *
@@ -224,11 +226,13 @@ class Stash {
 		}
 	}
 	
+	// ---------------------------------------------------------
+	
 	/**
 	 * Load the EE Template class and register the Stash module
 	 * Used when Stash is instantiated outside of an EE template
 	 *
-	 * @access public
+	 * @access private
 	 * @return void 
 	 */
 	private function _load_EE_TMPL()
@@ -1070,7 +1074,7 @@ class Stash {
 	/**
 	 * Set the current context
 	 *
-	 * @access protected
+	 * @access public
 	 * @return void
 	 */
 	public function context()
@@ -1551,6 +1555,8 @@ class Stash {
 	 * Bundle up a collection of variables and save in the database
 	 *
 	 * @access public
+	 * @param array $params 
+	 * @param array $dynamic 
 	 * @return void 
 	 */
 	public function bundle($params = array(), $dynamic = array())
@@ -1651,7 +1657,6 @@ class Stash {
 	 * Embed a Stash template file in the current template
 	 *
 	 * @access public
-	 * @param bool init Initialise the Stash object instance?
 	 * @return string 
 	 */
 	public function embed()
@@ -1739,7 +1744,9 @@ class Stash {
 		}
 	
 		return $this->_run_tag('get', $reserved_vars);
-	}	
+	}
+	
+	// ---------------------------------------------------------	
 	
 	/**
 	 * Parse tagdata
@@ -1782,22 +1789,9 @@ class Stash {
 		// set a default parse depth of 3
 		$this->EE->TMPL->tagparams['parse_depth'] = $this->EE->TMPL->fetch_param('parse_depth', 3);
 		
-		// initialise?
-		$init = (bool) preg_match('/1|on|yes|y/i', $this->EE->TMPL->fetch_param('init', 'yes'));
-		
-		// re-initialise parameters, unless disabled by init parameter
-		if ($init)
-		{
-			$this->init();
-		}
-		else
-		{
-			$this->process = 'inline';
-		}
-		
 		// postpone tag processing?
 		if ( $this->process !== 'inline') 
-		{
+		{	
 			if ($out = $this->_post_parse(__FUNCTION__)) return $out;
 		}
 		
@@ -1856,6 +1850,8 @@ class Stash {
 		return $is_match;
 	}
 	
+	// ---------------------------------------------------------
+	
 	/**
 	 * Retrieve and rebuild list, or optionally part of a list
 	 *
@@ -1908,6 +1904,8 @@ class Stash {
 		}		
 		return $list;
 	}
+	
+	// ---------------------------------------------------------
 	
 	/**
 	 * Retrieve {stash:var}{/stash:var} tag pairs and serialize
@@ -2043,9 +2041,9 @@ class Stash {
 	protected function sort_by_string($a, $b) 
 	{
 		return (strcasecmp($a[$this->_key2sort], $b[$this->_key2sort]));
-	} 
+	}
 	
-	// ---------------------------------------------------------
+	// --------------------------------------------------------- 
 	
 	/** 
 	 * Sort callback function: sort by integer
@@ -2080,7 +2078,7 @@ class Stash {
 			$name = str_replace('@', self::$context, $name);
 		}	
 		return $name;
-	}	
+	}
 	
 	// ---------------------------------------------------------
 	
@@ -2342,7 +2340,7 @@ class Stash {
 	}
 	
 	// ---------------------------------------------------------
-	
+		
 	/**
 	 * Final parsing of the stash variable before output to the template
 	 *
@@ -2391,6 +2389,7 @@ class Stash {
 	}
 	
 	// ---------------------------------------------------------
+	
 	/**
 	 * String manipulations
 	 *
@@ -2417,8 +2416,6 @@ class Stash {
 		if ($trim)
 		{
 			$value  = str_replace( array("\t", "\n", "\r", "\0", "\x0B"), '', trim($value));
-			
-			echo $value;
 		}
 
 		// strip tags?
@@ -2464,6 +2461,7 @@ class Stash {
 	}
 	
 	// ---------------------------------------------------------
+	
 	/**
 	 * Run a Stash module tag with a safe set of parameters
 	 *
@@ -2518,8 +2516,6 @@ class Stash {
 	// ---------------------------------------------------------
 	
 	/** 
-	 * _placeholders
-	 *
 	 * Replaces nested tag content with placeholders
 	 *
 	 * @access private
@@ -2537,6 +2533,7 @@ class Stash {
 	/**
 	 * process processing our method until template_post_parse hook
 	 * 
+	 * @access private
 	 * @param String	Method name (e.g. display, link or embed)
 	 * @return Mixed	TRUE if delay, FALSE if not
 	 */
@@ -2566,6 +2563,7 @@ class Stash {
 		
 		$cache[$placeholder] = array(
 			'method' 	=> $method,
+			'tagproper'	=> $this->EE->TMPL->tagproper,
 			'tagparams' => $this->EE->TMPL->tagparams,
 			'tagdata' 	=> $this->EE->TMPL->tagdata,
 			'priority' 	=> $this->priority
@@ -2576,8 +2574,11 @@ class Stash {
 	}
 	
 	// ---------------------------------------------------------
+	
 	/**
 	 * Prep {if var IN (array)} conditionals
+	 *
+	 * @access private
 	 * @param string $tagdata
 	 * @return String	
 	 */	
@@ -2610,6 +2611,7 @@ class Stash {
 	/**
 	 * get a users real IP address
 	 * 
+	 * @access private
 	 * @return String	
 	 */	
 	private function _get_real_ip() {


### PR DESCRIPTION
There's two things in this pull:

1) In EE 2.5+ we can now use the magic __call method in modules/plugins. So I added the following shortcut methods:

Single tag

```
{exp:stash:your_var_name}

//equivalent to

{exp:stash:get name="your_var_name"}
```

Tag pair

```
{exp:stash:your_var_name}
CONTENT
{/exp:stash:your_var_name}

//equivalent to

{exp:stash:set name="your_var_name"}
CONTENT
{/exp:stash:set}
```

2) added append="yes" and prepend="yes" params to stash:set

Not a big change, I know. To me this shortcut syntax feels more natural. What do you think?
