### PR TITLE
Feature/set alternate syntax

### DIFF
--- a/mod.stash.php
+++ b/mod.stash.php
@@ -649,7 +649,7 @@ class Stash {
 				{
 					if (strncmp($key, 'stash:', 6) ==  0)
 					{
-						$pattern = '/stash:([a-zA-Z0-9\-_]+)=([\042\047])?(.*?)\\2/Usi';
+						$pattern = '/stash:([a-zA-Z0-9\-_]+)\s*=\s*([\042\047])?(.*?)\\2/Usi';
 						preg_match($pattern, $key, $matches);
 						if (!empty($matches))
 						{		
@@ -2243,7 +2243,7 @@ class Stash {
 		{
 			if (strncmp($key, 'stash:', 6) ==  0)
 			{
-				$pattern = '/stash:([a-zA-Z0-9\-_]+)=([\042\047])?(.*?)\\2/Usi';
+				$pattern = '/stash:([a-zA-Z0-9\-_]+)\s*=\s*([\042\047])?(.*?)\\2/Usi';
 				preg_match($pattern, $key, $matches);
 				if (!empty($matches))
 				{


### PR DESCRIPTION
Maybe this is just me, but I sometimes find the current set tag pair syntax to be hard to read.

```
{exp:stash:set}
  {stash:channel}news{/stash:channel}
  {stash:limit}10{/stash:limit}
{/exp:stash:set}
```

This pull introduces a new, more concise syntax:

```
{exp:stash:set}
  {stash:channel="news"}
  {stash:limit="10"}
{/exp:stash:set}
```

The is the "setter" syntax used by the native preload_replace template tag.

You can also use whitespace before and after the equals sign, so you can line up your "params" if you so desire.

```
{exp:stash:set}
  {stash:channel = "news"}
  {stash:limit   = "10"}
{/exp:stash:set}
```

This was just an idea I had, maybe you'll find it useful. Or maybe not.
