### PR TITLE
Check if HTTP_USER_AGENT is set.

### DIFF
--- a/mod.stash.php
+++ b/mod.stash.php
@@ -2997,7 +2997,7 @@ class Stash {
 	 */	
 	private function _is_bot() 
 	{	
-		$bot_test = strtolower($_SERVER['HTTP_USER_AGENT']);
+		$bot_test = isset($_SERVER['HTTP_USER_AGENT']) ? strtolower($_SERVER['HTTP_USER_AGENT']) : (php_sapi_name() === 'cli' ? 'cli' : 'other');
 		$is_bot = FALSE;
 	
 		if (empty($bot_test)) 


### PR DESCRIPTION
In some circumstances the HTTP_USER_AGENT server variable is not set (CLI execution) which resulted in a PHP notice. By setting $bot_test to 'cli' or 'other', we have more possibilities to fine-tune the bot control.
