### PR TITLE
Add {exp:stash:is_empty} tag

### DIFF
--- a/mod.stash.php
+++ b/mod.stash.php
@@ -1250,6 +1250,32 @@ class Stash {
 		$value	= str_replace( array("\t", "\n", "\r", "\0", "\x0B"), '', trim($test));
 		return empty( $value ) ? 0 : 1;
 	}	
+
+	// ---------------------------------------------------------
+
+	/**
+	 * Checks if a variable or string has any content, handy for conditionals
+	 *
+	 * @access public
+	 * @param $string a string to test
+	 * @return integer
+	 */
+	public function is_empty($string = NULL)
+	{
+		/* Sample use
+		---------------------------------------------------------
+		Check a native stash variable, global variable or snippet is empty:
+		{if {exp:stash:is_empty type="snippet" name="title"} }
+			Yes! {title} is empty
+		{/if}
+
+		Check any string or variable is not empty even if it's not been Stashed:
+		{if {exp:stash:is_empty:string}{my_string}{/exp:stash:is_empty:string} }
+			Yes! {my_string} is empty
+		{/if}
+		--------------------------------------------------------- */
+		return ! $this->not_empty($string);
+	}
 	
 	// ---------------------------------------------------------
 	


### PR DESCRIPTION
Just a tiny little pull request for your consideration. I often find a need to test if a Stash variable IS empty, rather that if it is not. So I added an {exp:stash:is_empty} tag that is the exact negative of {exp:stash:not_empty}. Maybe there is a better way to handle this, but here's my code (all one line of it) in case you want it.
