### PR TITLE
Add Composer compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "croxton/stash",
-    "description": "Config bootstrap for ExpressionEngine 2.x",
+    "description": "Extended templating for ExpressionEngine",
     "homepage": "https://github.com/croxton/Stash",
     "authors": [
         {
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.11"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Ideally, you'd have it on Packagist: https://packagist.org/about and set up a GitHub service hook so it updated every time you pushed.

That's not necessary however, even with just the composer.json file, users could manually put in the git repo like so:

``` json
{
  "require": {
    "croxton/stash": "2.5.*@dev"
  },
  "repositories": [
    {
      "type": "vcs",
      "url": "https://github.com/timkelty/Stash.git"
    }
  ],
  "config": {
    "vendor-dir": "vendor/composer"
  },
  "minimum-stability": "dev"
}
```

Another note - The alias of "dev-dev" might look funny. Generally this is "dev-master", assuming master is the "newest" branch, and the developer is using some sort of "stable" branch, In your case, you're using master for stable and dev for latest, hence "dev-dev". The purpose of the alias is so that a user can just reference dev-master (or dev-dev) in your case and always get the latest regardless of vcs bumps. 
