### PR TITLE
Update mod.stash.php to fix match/against in ee3

### DIFF
--- a/system/user/addons/stash/mod.stash.php
+++ b/system/user/addons/stash/mod.stash.php
@@ -3260,7 +3260,7 @@ class Stash {
     private function _matches($match, $against)
     {
         $is_match = TRUE;
-        $match = ee()->security->entity_decode($match);
+        $match = ee('Security/XSS')->entity_decode($match);
 
         if ( ! is_array($against)) 
         {


### PR DESCRIPTION
The "old way" gave this error:
`Fatal error: Call to undefined method EE_Security::entity_decode() in /system/user/addons/stash/mod.stash.php on line 3263`

I've copied this fix from what you've done in switchee.

-
First time I use Github this way, so I'm not really sure if this is the preferred way to handle this or not?