### PR TITLE
Fixing deprecated assign_variables fxn

### DIFF
--- a/system/user/addons/stash/mod.stash.php
+++ b/system/user/addons/stash/mod.stash.php
@@ -725,7 +725,8 @@ class Stash {
                 // this permits dynamic tag pairs, e.g. {stash:{key}}{/stash:{key}} 
                 if ($this->parse_complete)
                 {
-                    $tag_vars = ee()->functions->assign_variables(ee()->TMPL->tagdata);
+                    // $tag_vars = ee()->functions->assign_variables(ee()->TMPL->tagdata);
+                    $tag_vars = ee('Variables/Parser')->extractVariables(ee()->TMPL->tagdata);
                     $tag_pairs = $tag_vars['var_pair'];
                 }
                 else


### PR DESCRIPTION
This changes the `assign_variables` function, which is deprecated, to use `ee('Variables/Parser')->extractVariables()`, on the ee3 branch.