### PR TITLE
Fix for PHP 8.1.6 deprecation.

### DIFF
--- a/system/user/addons/stash/mod.stash.php
+++ b/system/user/addons/stash/mod.stash.php
@@ -4409,7 +4409,7 @@ class Stash {
         {
             foreach (ee()->config->_global_vars as $key => $val)
             {
-                $template = str_replace(LD.$key.RD, $val, $template);
+                $template = str_replace(LD.$key.RD, (string) $val, $template);
             }   
         }
         


### PR DESCRIPTION
str_replace(): Passing null to parameter #2 ($replace) of type array|string is deprecated